### PR TITLE
Fixing Spacing Issues

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,5 +23,6 @@ export const colorMap: Record<string, string> = {
     'yellow': '#FFFF00',
     'orange': '#FFA500',
     'purple': '#800080',
+    'black': "#000000"
     // TODO Add more colors as needed
   };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,27 @@
+export const headingSizes: Record<string, number> = {
+  h1: 32,
+  h2: 24,
+  h3: 18.72,
+  h4: 16,
+  h5: 13.28,
+  h6: 10.72,
+};
+
+export const inverseHeadingSizes: Record<string, string> = {
+  '32': 'h1',
+  '24': 'h2',
+  '18.72': 'h3',
+  '16': 'h4',
+  '13.28': 'h5',
+  '10.72': 'h6',
+};
+
+export const colorMap: Record<string, string> = {
+    'red': '#FF0000',
+    'green': '#00FF00',
+    'blue': '#0000FF',
+    'yellow': '#FFFF00',
+    'orange': '#FFA500',
+    'purple': '#800080',
+    // TODO Add more colors as needed
+  };

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -1,5 +1,5 @@
 import { TextStyle, TextSegment, PositionedTextSegment, TextMeasurement, HTMLToVegaLiteOptions } from './types';
-import { inverseHeadingSizes } from './constants';
+import { colorMap, inverseHeadingSizes } from './constants';
 
 /**
  * Text layout engine that positions text segments
@@ -108,7 +108,7 @@ export class TextLayoutEngine {
       segment.fontWeight === 'normal' &&
       segment.fontStyle === 'normal' &&
       segment.textDecoration === 'none' &&
-      (!color || color === '#000' || color === '#000000')
+      (!color || color === colorMap['black'])
     );
   }
 

--- a/src/strategies/implementations/color-tag-strategy.ts
+++ b/src/strategies/implementations/color-tag-strategy.ts
@@ -1,22 +1,14 @@
 import { TextStyle } from '../../types';
 import { BaseTagStrategy } from '../interfaces/base-tag-strategy';
+import { colorMap } from '../../constants';
 
 /**
  * Example custom strategy for color tags like <red>, <green>, <blue>
  */
 export class ColorTagStrategy extends BaseTagStrategy {
-  private colorMap: Record<string, string> = {
-    'red': '#FF0000',
-    'green': '#00FF00',
-    'blue': '#0000FF',
-    'yellow': '#FFFF00',
-    'orange': '#FFA500',
-    'purple': '#800080',
-    // TODO Add more colors as needed
-  };
 
   public applyStyle(currentStyle: TextStyle, attributes: string, tagName?: string): TextStyle {
-    const color = this.colorMap[tagName || ''];
+    const color = colorMap[tagName || ''];
     
     return {
       ...currentStyle,
@@ -25,6 +17,6 @@ export class ColorTagStrategy extends BaseTagStrategy {
   }
 
   public getTagNames(): string[] {
-    return Object.keys(this.colorMap);
+    return Object.keys(colorMap);
   }
 }

--- a/src/strategies/implementations/heading-tag-strategy.ts
+++ b/src/strategies/implementations/heading-tag-strategy.ts
@@ -1,22 +1,15 @@
 import { TextStyle } from '../../types';
 import { BaseTagStrategy } from '../interfaces/base-tag-strategy';
+import { headingSizes } from '../../constants';
 
 /**
  * Strategy for heading tags: <h1>, <h2>, <h3>, <h4>, <h5>, <h6>
  */
 export class HeadingTagStrategy extends BaseTagStrategy {
-  private headingSizes: Record<string, number> = {
-    'h1': 32,
-    'h2': 24,
-    'h3': 18.72,
-    'h4': 16,
-    'h5': 13.28,
-    'h6': 10.72
-  };
 
   public applyStyle(currentStyle: TextStyle, attributes: string, tagName?: string): TextStyle {
     // Extract tag name from the attributes or context
-    const fontSize = tagName ? this.headingSizes[tagName.toLowerCase()] || 16 : (currentStyle.fontSize || 16);
+    const fontSize = tagName ? headingSizes[tagName.toLowerCase()] || 16 : (currentStyle.fontSize || 16);
     
     return {
       ...currentStyle,
@@ -33,6 +26,6 @@ export class HeadingTagStrategy extends BaseTagStrategy {
    * Get font size for a specific heading level
    */
   public getFontSize(tagName: string): number {
-    return this.headingSizes[tagName.toLowerCase()] || 16;
+    return headingSizes[tagName.toLowerCase()] || 16;
   }
 }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -164,7 +164,7 @@ describe('Integration Tests', () => {
       const positioned = converter.layoutSegments(parseResult.segments);
       expect(positioned).toHaveLength(3);
       expect(positioned[0].x).toBe(0); // startX
-      expect(positioned[0].y).toBe(0); // startY
+      expect(positioned[0].y).toBe(4); // startY
       expect(positioned[1].x).toBeGreaterThan(positioned[0].x); // Should advance
       expect(positioned[2].x).toBeGreaterThan(positioned[1].x); // Should advance further
 

--- a/tests/layout.test.ts
+++ b/tests/layout.test.ts
@@ -39,8 +39,8 @@ describe('TextLayoutEngine', () => {
 
       expect(positioned).toHaveLength(1);
       expect(positioned[0].text).toBe('Hello World');
-      expect(positioned[0].x).toBe(10); // startX
-      expect(positioned[0].y).toBe(30); // startY
+      expect(positioned[0].x).toBe(12); // startX (offset for unstyled text)
+      expect(positioned[0].y).toBe(36); // startY
       expect(positioned[0].fontWeight).toBe('normal');
       expect(positioned[0].fontStyle).toBe('normal');
       expect(positioned[0].color).toBe('#000000');
@@ -109,7 +109,7 @@ describe('TextLayoutEngine', () => {
       expect(positioned).toHaveLength(1);
       expect(positioned[0].text).toBe('');
       expect(positioned[0].x).toBe(10);
-      expect(positioned[0].y).toBe(30);
+      expect(positioned[0].y).toBe(36);
     });
 
     it('should position segments with different font weights correctly', () => {
@@ -296,7 +296,7 @@ describe('TextLayoutEngine', () => {
       const positioned = layoutEngine.layoutSegments(segments);
 
       expect(positioned[0].x).toBe(20); // New startX
-      expect(positioned[0].y).toBe(40); // New startY
+      expect(positioned[0].y).toBe(48); // New startY (Change in vertical positioning after Heading)
     });
   });
 
@@ -348,6 +348,61 @@ describe('TextLayoutEngine', () => {
       expect(positioned).toHaveLength(2);
       expect(positioned[0].fontWeight).toBe('normal');
       expect(positioned[1].fontWeight).toBe('bold');
+    });
+
+    it('should handle space between two adjecent tags', () => {
+      const segments: TextSegment[] = [
+        {
+          text: 'italics text',
+          fontWeight: 'normal',
+          fontStyle: 'italic',
+          color: '#000000'
+        },
+        {
+          text: 'Bold text',
+          fontWeight: 'bold',
+          fontStyle: 'normal',
+          color: '#000000'
+        }
+      ];
+
+      const positioned = layoutEngine.layoutSegments(segments);
+
+      // Both should be positioned, with a space between the two segements.
+      expect(positioned).toHaveLength(2);
+      expect(positioned[0].fontStyle).toBe('italic');
+      expect(positioned[0].fontWeight).toBe('normal');
+      expect(positioned[1].fontWeight).toBe('bold');
+      expect(positioned[1].fontStyle).toBe('normal');
+
+      // Check X positioning
+      const firstSegmentRight = positioned[0].x + positioned[0].width;
+      const secondSegmentX = positioned[1].x;  
+
+      // Measure expected space width
+      const spaceWidth = layoutEngine.measureText(' ', positioned[0]).width;
+
+      // Assert spacing is at least 1 space wide (with slight tolerance)
+      expect(secondSegmentX).toBeCloseTo(firstSegmentRight + spaceWidth, 1);
+    });
+
+    it('should have appropriate vertical spacing for heading tag', () => {
+      const segments: TextSegment[] = [
+        {
+          text: 'Heading 1',
+          fontSize: 32,
+          fontWeight: 'bold',
+          fontStyle: 'normal',
+          color: '#000000'
+        },
+      ];
+
+      const positioned = layoutEngine.layoutSegments(segments);
+
+      // Both should be positioned, with adequate vertical spacing
+      expect(positioned).toHaveLength(1);
+      expect(positioned[0].fontSize).toBe(32);
+      expect(positioned[0].y).toBe(30);
     });
   });
 

--- a/tests/strategies.test.ts
+++ b/tests/strategies.test.ts
@@ -350,7 +350,7 @@ describe('Tag Strategies', () => {
 
     it('should return correct tag names', () => {
       const tagNames = strategy.getTagNames();
-      expect(tagNames).toEqual(['red', 'green', 'blue', 'yellow', 'orange', 'purple']);
+      expect(tagNames).toEqual(['red', 'green', 'blue', 'yellow', 'orange', 'purple', 'black']);
     });
 
     it('should apply red color', () => {


### PR DESCRIPTION
# Summary
This PR solves two spacing related issues in the HTML to vegalite converter:
1. The word spacing between two words were NIL, particularly with segments having HTML styling.
2. The vertical spacing between heading tags were inconsistent leading to overlapping.

# Details

## Issue 1: Word Spacing
### Example 1

**HTML**
`
<b>Bold text</b> and <i>italic text</i> with <strong>strong</strong> and <em>emphasis</em>
`

**Before Fix:**
<img width="1192" height="251" alt="image" src="https://github.com/user-attachments/assets/a327ace4-595f-4aad-aa94-15051a31d52b" />

**After Fix:**
<img width="945" height="235" alt="image" src="https://github.com/user-attachments/assets/b6a48a2d-2b7b-464f-b752-5015f3927610" />

### Example 2
**HTML**
`
This text has <u>underlined</u> content for <u><b>Emphasis</b></u>
`

**Before Fix:**
<img width="962" height="165" alt="image" src="https://github.com/user-attachments/assets/3aadb981-f276-4629-8499-02d3dee20fcd" />

**After Fix:**
<img width="992" height="220" alt="image" src="https://github.com/user-attachments/assets/dd0876cb-45e8-4bc9-b31b-de25d199b456" />


## Issue 2: Vertical Heading Spacing

**HTML**
`
<u><h1>Main Title</h1></u> <u><h2>Subtitle</h2></u> <u><h3>Section</h3></u> <u><h4>Subsection</h4></u>
`

**Before Fix:**
<img width="836" height="199" alt="image" src="https://github.com/user-attachments/assets/fabda931-a3e0-4167-9b1c-2f4e44471c55" />

**After Fix:**
<img width="411" height="346" alt="image" src="https://github.com/user-attachments/assets/ada9f397-23e3-46a0-a02f-d628007bf441" />