### PR TITLE
Resolving Spacing Bugs in KPI cards

### DIFF
--- a/src/strategies/implementations/hyperlink-tag-strategy.ts
+++ b/src/strategies/implementations/hyperlink-tag-strategy.ts
@@ -1,8 +1,11 @@
-import { TextStyle, ParseContext, ParsedOutput } from '../../types';
+import { TextStyle } from '../../types';
 import { BaseTagStrategy } from '../interfaces/base-tag-strategy';
 
 /**
  * Strategy for hyperlink tags: <a href="...">
+ * 
+ * This strategy applies link styling (color and underline) and validates href attributes.
+ * Uses the default parse() implementation from BaseTagStrategy.
  */
 export class HyperlinkTagStrategy extends BaseTagStrategy {
   public applyStyle(currentStyle: TextStyle, attributes: string, tagName?: string): TextStyle {
@@ -15,40 +18,6 @@ export class HyperlinkTagStrategy extends BaseTagStrategy {
       textDecoration: 'underline'
       // We may further add if needed:
       // href: hrefMatch ? hrefMatch[1] : undefined
-    };
-  }
-
-  public parse(context: ParseContext): ParsedOutput {
-    const { isClosingTag, attributes, currentStyle } = context;
-
-    if (isClosingTag) {
-      // For closing tags, just pop from style stack
-      return {
-        newSegments: [],
-        updatedStyle: currentStyle, // Will be ignored since we're popping
-        pushStyleToStack: false,
-        popFromStyleStack: true,
-        errors: []
-      };
-    }
-
-    // For opening tags, validate and apply styling
-    const errors: string[] = [];
-    if (this.validateAttributes) {
-      const validation = this.validateAttributes(attributes);
-      if (!validation.isValid) {
-        errors.push(...validation.errors);
-      }
-    }
-
-    const newStyle = this.applyStyle(currentStyle, attributes, context.tagName);
-
-    return {
-      newSegments: [],
-      updatedStyle: newStyle,
-      pushStyleToStack: true,
-      popFromStyleStack: false,
-      errors
     };
   }
 

--- a/src/strategies/implementations/hyperlink-tag-strategy.ts
+++ b/src/strategies/implementations/hyperlink-tag-strategy.ts
@@ -14,9 +14,8 @@ export class HyperlinkTagStrategy extends BaseTagStrategy {
     return {
       ...currentStyle,
       color: '#0066CC', // Traditional link blue
-      textDecoration: 'underline'
-      // We may further add if needed:
-      // href: hrefMatch ? hrefMatch[1] : undefined
+      textDecoration: 'underline',
+      href: hrefMatch ? hrefMatch[1] : undefined,
     };
   }
 

--- a/src/strategies/implementations/hyperlink-tag-strategy.ts
+++ b/src/strategies/implementations/hyperlink-tag-strategy.ts
@@ -5,7 +5,6 @@ import { BaseTagStrategy } from '../interfaces/base-tag-strategy';
  * Strategy for hyperlink tags: <a href="...">
  * 
  * This strategy applies link styling (color and underline) and validates href attributes.
- * Uses the default parse() implementation from BaseTagStrategy.
  */
 export class HyperlinkTagStrategy extends BaseTagStrategy {
   public applyStyle(currentStyle: TextStyle, attributes: string, tagName?: string): TextStyle {

--- a/src/strategies/implementations/span-tag-strategy.ts
+++ b/src/strategies/implementations/span-tag-strategy.ts
@@ -1,9 +1,12 @@
-import { TextStyle, ParseContext, ParsedOutput } from '../../types';
+import { TextStyle } from '../../types';
 import { BaseTagStrategy } from '../interfaces/base-tag-strategy';
 import { StyleHelpers } from '../../helpers/style';
 
 /**
  * Strategy for span tags with style attributes: <span style="...">
+ * 
+ * This strategy parses CSS style attributes and applies them to text.
+ * Uses the default parse() implementation from BaseTagStrategy.
  */
 export class SpanTagStrategy extends BaseTagStrategy {
   public applyStyle(currentStyle: TextStyle, attributes: string, tagName?: string): TextStyle {
@@ -18,40 +21,6 @@ export class SpanTagStrategy extends BaseTagStrategy {
     return newStyle;
   }
 
-  public parse(context: ParseContext): ParsedOutput {
-    const { isClosingTag, attributes, currentStyle } = context;
-
-    if (isClosingTag) {
-      // For closing tags, just pop from style stack
-      return {
-        newSegments: [],
-        updatedStyle: currentStyle, // Will be ignored since we're popping
-        pushStyleToStack: false,
-        popFromStyleStack: true,
-        errors: []
-      };
-    }
-
-    // For opening tags, validate and apply styling
-    const errors: string[] = [];
-    if (this.validateAttributes) {
-      const validation = this.validateAttributes(attributes);
-      if (!validation.isValid) {
-        errors.push(...validation.errors);
-      }
-    }
-
-    const newStyle = this.applyStyle(currentStyle, attributes, context.tagName);
-
-    return {
-      newSegments: [],
-      updatedStyle: newStyle,
-      pushStyleToStack: true,
-      popFromStyleStack: false,
-      errors
-    };
-  }
-
   public getTagNames(): string[] {
     return ['span'];
   }
@@ -59,6 +28,4 @@ export class SpanTagStrategy extends BaseTagStrategy {
   public validateAttributes(attributes: string): { isValid: boolean; errors: string[] } {
     return StyleHelpers.validateStyleAttribute(attributes);
   }
-
-
 }

--- a/src/strategies/implementations/span-tag-strategy.ts
+++ b/src/strategies/implementations/span-tag-strategy.ts
@@ -6,7 +6,6 @@ import { StyleHelpers } from '../../helpers/style';
  * Strategy for span tags with style attributes: <span style="...">
  * 
  * This strategy parses CSS style attributes and applies them to text.
- * Uses the default parse() implementation from BaseTagStrategy.
  */
 export class SpanTagStrategy extends BaseTagStrategy {
   public applyStyle(currentStyle: TextStyle, attributes: string, tagName?: string): TextStyle {

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,18 +156,18 @@ export interface VegaLiteRuleEncoding {
  * Vega-Lite encoding configuration
  */
 export interface VegaLiteEncoding {
-  x: {
-    field: string;
-    type: 'quantitative';
-    axis: null;
-    scale: { domain: number[] };
-  };
-  y: {
-    field: string;
-    type: 'quantitative';
-    axis: null;
-    scale: { domain: number[] };
-  };
+    x: {
+      field: string;
+      type: 'quantitative';
+      axis: null;
+      scale: null | { domain: number[] };
+    };
+    y: {
+      field: string;
+      type: 'quantitative';
+      axis: null;
+      scale: null | { domain: number[] };
+    };
   text: {
     field: string;
     type: 'nominal';

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,18 +156,18 @@ export interface VegaLiteRuleEncoding {
  * Vega-Lite encoding configuration
  */
 export interface VegaLiteEncoding {
-    x: {
-      field: string;
-      type: 'quantitative';
-      axis: null;
-      scale: null | { domain: number[] };
-    };
-    y: {
-      field: string;
-      type: 'quantitative';
-      axis: null;
-      scale: null | { domain: number[] };
-    };
+  x: {
+    field: string;
+    type: 'quantitative';
+    axis: null;
+    scale: null | { domain: number[] };
+  };
+  y: {
+    field: string;
+    type: 'quantitative';
+    axis: null;
+    scale: null | { domain: number[] };
+  };
   text: {
     field: string;
     type: 'nominal';

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface TextStyle {
   textDecoration?: 'none' | 'underline' | 'line-through';
   fontSize?: number;
   verticalOffset?: number; // Negative for superscript, positive for subscript
+  href?: string | undefined; // URL for hyperlinks
   // List context properties
   isListItem?: boolean;
   listNestingLevel?: number;
@@ -73,6 +74,7 @@ export interface VegaLiteLayerData {
   y: number;
   width?: number;
   height?: number;
+  href?: string | undefined;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,13 +116,13 @@ export interface VegaLiteTextEncoding {
     field: 'x';
     type: 'quantitative';
     axis: null;
-    scale: { domain: [number, number] };
+    scale: null | { domain: number[] };
   };
   y: {
     field: 'y';
     type: 'quantitative';
     axis: null;
-    scale: { domain: [number, number] };
+    scale: null | { domain: number[] };
   };
   text: {
     field: 'text';

--- a/src/vega-generator.ts
+++ b/src/vega-generator.ts
@@ -70,7 +70,8 @@ export class VegaLiteGenerator {
             fontStyle: segment.fontStyle,
             color: segment.color,
             textDecoration: segment.textDecoration ?? 'none',
-            fontSize: segment.fontSize ?? this.fontSize
+            fontSize: segment.fontSize ?? this.fontSize,
+            href: segment.href ?? undefined,
           },
           data: []
         };
@@ -82,7 +83,8 @@ export class VegaLiteGenerator {
         x: segment.x,
         y: segment.y,
         width: segment.width,
-        height: segment.height
+        height: segment.height,
+        href: segment.href
       });
     });
 
@@ -93,7 +95,7 @@ export class VegaLiteGenerator {
    * Create a unique key for style grouping
    */
   private createStyleKey(segment: PositionedTextSegment): string {
-    return `${segment.fontWeight}-${segment.fontStyle}-${segment.color}-${segment.textDecoration ?? 'none'}-${segment.fontSize ?? 'default'}`;
+    return `${segment.fontWeight}-${segment.fontStyle}-${segment.color}-${segment.textDecoration ?? 'none'}-${segment.fontSize ?? 'default'}-${segment.href ?? 'no-link'}`;
   }
 
   /**
@@ -137,7 +139,7 @@ export class VegaLiteGenerator {
     const fontSize = options.fontSize || group.style.fontSize || baseFontSize;
     
     // Keep original coordinates since we're using 'top' baseline
-    return {
+    const layer: any = {
       data: { values: group.data },
       mark: {
         type: 'text',
@@ -147,7 +149,8 @@ export class VegaLiteGenerator {
         fontStyle: group.style.fontStyle,
         color: group.style.color,
         align: 'left',
-        baseline: 'top'
+        baseline: 'top',
+        cursor: group.style.href ? 'pointer' : 'default'
       },
       encoding: {
         x: {
@@ -168,6 +171,16 @@ export class VegaLiteGenerator {
         }
       }
     };
+
+    // Add href encoding if this is a hyperlink
+    if (group.style.href) {
+      layer.encoding.href = {
+        field: 'href',
+        type: 'nominal'
+      };
+    }
+
+    return layer;
   }
 
   /**

--- a/src/vega-generator.ts
+++ b/src/vega-generator.ts
@@ -201,13 +201,13 @@ export class VegaLiteGenerator {
             field: 'x',
             type: 'quantitative',
             axis: null,
-            scale: { domain: [0, 200] }
+            scale: null
           },
           y: {
             field: 'y',
             type: 'quantitative',
             axis: null,
-            scale: { domain: [0, 50] }
+            scale: null
           },
           text: {
             field: 'text',

--- a/src/vega-generator.ts
+++ b/src/vega-generator.ts
@@ -154,13 +154,13 @@ export class VegaLiteGenerator {
           field: 'x',
           type: 'quantitative',
           axis: null,
-          scale: { domain: [0, bounds.width] }
+          scale: null
         },
         y: {
           field: 'y',
           type: 'quantitative',
           axis: null,
-          scale: { domain: [bounds.height, 0] }  // Invert Y domain to match top-down layout
+          scale: null
         },
         text: {
           field: 'text',
@@ -265,7 +265,7 @@ export class VegaLiteGenerator {
           field: 'x',
           type: 'quantitative',
           axis: null,
-          scale: { domain: [0, bounds.width] }
+          scale: null
         },
         x2: {
           field: 'x2',
@@ -275,7 +275,7 @@ export class VegaLiteGenerator {
           field: 'y',
           type: 'quantitative',
           axis: null,
-          scale: { domain: [bounds.height, 0] }  // Invert Y domain to match top-down layout
+          scale: null
         }
       }
     };
@@ -316,7 +316,7 @@ export class VegaLiteGenerator {
           field: 'x',
           type: 'quantitative',
           axis: null,
-          scale: { domain: [0, bounds.width] }
+          scale: null
         },
         x2: {
           field: 'x2',
@@ -326,7 +326,7 @@ export class VegaLiteGenerator {
           field: 'y',
           type: 'quantitative',
           axis: null,
-          scale: { domain: [bounds.height, 0] }  // Invert Y domain to match top-down layout
+          scale: null
         }
       }
     };

--- a/tests/vega-generator.test.ts
+++ b/tests/vega-generator.test.ts
@@ -252,13 +252,13 @@ describe('VegaLiteGenerator', () => {
         field: 'x',
         type: 'quantitative',
         axis: null,
-        scale: { domain: [0, 200] }
+        scale: null
       });
       expect(layer.encoding.y).toEqual({
         field: 'y',
         type: 'quantitative',
         axis: null,
-        scale: { domain: [50, 0] }  // Inverted Y domain for top-down layout
+        scale: null
       });
       expect(layer.encoding.text).toEqual({
         field: 'text',


### PR DESCRIPTION
# Summary

This PR introduces the following changes:
- Fixes minor bugs related to relative spacing while integrating with other charts.
- Removes redundant code in `HyperlinkTagStrategy` and `SpanTagStrategy`.
- Adding Missing href to Hyperlink Tags.

# Details

While integrating with normal charts to create KPI cards, the html styling were breaking as the spacing and layout between the elements where dynamically changing with respect to the Size of the container. 

Before FIX:
![KPI before](https://github.com/user-attachments/assets/2cb71278-1fa3-407c-9344-9fa89962af8c)

After FIX:
![KPI](https://github.com/user-attachments/assets/10f1787b-e2c8-43e4-a00d-1777022380bd)

**Headings and Lists Example**
<img width="921" height="603" alt="image" src="https://github.com/user-attachments/assets/0d44e34f-6550-428f-b5c6-bc816a2d81a1" />

